### PR TITLE
[iOS16] support live activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ APNS/2 is a go package designed for simple, flexible and fast Apple Push Notific
 - Supports new Apple Token Based Authentication (JWT)
 - Supports new iOS 10 features such as Collapse IDs, Subtitles and Mutable Notifications
 - Supports new iOS 15 features interruptionLevel and relevanceScore
+- Supports iOS 16 features for live-activity notifications
 - Supports persistent connections to APNs
 - Supports VoIP/PushKit notifications (iOS 8 and later)
 - Modular & easy to use

--- a/client_test.go
+++ b/client_test.go
@@ -322,6 +322,18 @@ func TestPushTypeMDMHeader(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPushTypeLiveActivityHeader(t *testing.T) {
+	notification := mockNotification()
+	notification.PushType = apns.PushTypeLiveActivity
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "liveactivity", r.Header.Get("apns-push-type"))
+	}))
+
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(notification)
+	assert.NoError(t, err)
+}
+
 func TestAuthorizationHeader(t *testing.T) {
 	n := mockNotification()
 	token := mockToken()

--- a/notification.go
+++ b/notification.go
@@ -63,6 +63,11 @@ const (
 	// contact the MDM server. If you set this push type, you must use the topic
 	// from the UID attribute in the subject of your MDM push certificate.
 	PushTypeMDM EPushType = "mdm"
+
+	// PushTypeLiveActivity to signal changes to a live activity session.
+	// The liveactivity push type isn’t available on watchOS, macOS, and tvOS.
+	// It’s recommended on iOS and iPadOS.
+	PushTypeLiveActivity EPushType = "liveactivity"
 )
 
 const (

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -40,6 +40,9 @@ type aps struct {
 	Sound             interface{}        `json:"sound,omitempty"`
 	ThreadID          string             `json:"thread-id,omitempty"`
 	URLArgs           []string           `json:"url-args,omitempty"`
+	StaleDate         int64              `json:"stale-date,omitempty"`
+	Event             string             `json:"event,omitempty"`
+	Timestamp         int64              `json:"timestamp,omitempty"`
 }
 
 type alert struct {
@@ -218,7 +221,7 @@ func (p *Payload) AlertLaunchImage(image string) *Payload {
 // specifiers in loc-key. See Localized Formatted Strings in Apple
 // documentation for more information.
 //
-//  {"aps":{"alert":{"loc-args":args}}}
+//	{"aps":{"alert":{"loc-args":args}}}
 func (p *Payload) AlertLocArgs(args []string) *Payload {
 	p.aps().alert().LocArgs = args
 	return p
@@ -375,6 +378,24 @@ func (p *Payload) RelevanceScore(b float32) *Payload {
 //	{"aps":{"relevance-score":0.1}}
 func (p *Payload) UnsetRelevanceScore() *Payload {
 	p.aps().RelevanceScore = nil
+	return p
+}
+
+// {"aps":{"stale-date":1650998941}}
+func (p *Payload) StaleDate(staledate int64) *Payload {
+	p.aps().StaleDate = staledate
+	return p
+}
+
+// {"aps":{"event":"update"}}
+func (p *Payload) Event(event string) *Payload {
+	p.aps().Event = event
+	return p
+}
+
+// {"aps":{"timestamp":1168364460}}
+func (p *Payload) Timestamp(value int64) *Payload {
+	p.aps().Timestamp = value
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -390,8 +390,8 @@ func (p *Payload) UnsetRelevanceScore() *Payload {
 // ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
 // {"aps":{"stale-date":1650998941}}
-func (p *Payload) StaleDate(staledate int64) *Payload {
-	p.aps().StaleDate = staledate
+func (p *Payload) StaleDate(staleDate int64) *Payload {
+	p.aps().StaleDate = staleDate
 	return p
 }
 
@@ -400,8 +400,8 @@ func (p *Payload) StaleDate(staledate int64) *Payload {
 // ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
 // {"aps":{"dismissal-date":1650998945}}
-func (p *Payload) DismissalDate(dismissaldate int64) *Payload {
-	p.aps().DismissalDate = dismissaldate
+func (p *Payload) DismissalDate(dismissalDate int64) *Payload {
+	p.aps().DismissalDate = dismissalDate
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -384,24 +384,41 @@ func (p *Payload) UnsetRelevanceScore() *Payload {
 	return p
 }
 
+// StaleDate defines the value stale-date for the aps payload
+// The date when the system considers an update to the Live Activity to be out of date.
+// ref: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
 // {"aps":{"stale-date":1650998941}}
 func (p *Payload) StaleDate(staledate int64) *Payload {
 	p.aps().StaleDate = staledate
 	return p
 }
 
+// Event defines the value event for the aps payload
+// Describes whether you update or end an ongoing Live Activity
+// ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
+//
 // {"aps":{"event":"update"}}
 func (p *Payload) Event(event string) *Payload {
 	p.aps().Event = event
 	return p
 }
 
+// Timestamp defines the value timestamp for the aps payload
+// The UNIX timestamp that marks the time when you send the remote notification that updates or ends a Live Activity
+// ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
+//
 // {"aps":{"timestamp":1168364460}}
 func (p *Payload) Timestamp(value int64) *Payload {
 	p.aps().Timestamp = value
 	return p
 }
 
+// ContentState defines the value content-state for aps payload
+// Describes and contains the dynamic content of a Live Activity.
+// ref :https://developer.apple.com/documentation/activitykit/activity/contentstate-swift.typealias
+//
+// {"aps":{"content-state":{"product_id": 123456, "product_name": "nameTest", "product_quantity": 4, "delivery_time": 34}}}
 func (p *Payload) ContentState(content map[string]interface{}) *Payload {
 	p.aps().ContentState = content
 	return p

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -409,7 +409,7 @@ func (p *Payload) DismissalDate(dismissaldate int64) *Payload {
 // Describes whether you update or end an ongoing Live Activity
 // ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
-// {"aps":{"events":"update"}}
+// {"aps":{"event":"update"}}
 func (p *Payload) Event(event string) *Payload {
 	p.aps().Event = event
 	return p

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -43,7 +43,8 @@ type aps struct {
 	ThreadID          string                 `json:"thread-id,omitempty"`
 	URLArgs           []string               `json:"url-args,omitempty"`
 	StaleDate         int64                  `json:"stale-date,omitempty"`
-	Events            string                 `json:"event,omitempty"`
+	DismissalDate     int64                  `json:"dismissal-date,omitempty"`
+	Event             string                 `json:"event,omitempty"`
 	Timestamp         int64                  `json:"timestamp,omitempty"`
 	ContentState      map[string]interface{} `json:"content-state,omitempty"`
 }
@@ -386,11 +387,21 @@ func (p *Payload) UnsetRelevanceScore() *Payload {
 
 // StaleDate defines the value stale-date for the aps payload
 // The date when the system considers an update to the Live Activity to be out of date.
-// ref: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+// ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
 // {"aps":{"stale-date":1650998941}}
 func (p *Payload) StaleDate(staledate int64) *Payload {
 	p.aps().StaleDate = staledate
+	return p
+}
+
+// DismissalDate defines the value dismissal-date for the aps payload
+// The UNIX timestamp that represents the date at which the system ends a Live Activity and removes it from the Dynamic Island and the Lock Screen
+// ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
+//
+// {"aps":{"dismissal-date":1650998945}}
+func (p *Payload) DismissalDate(dismissaldate int64) *Payload {
+	p.aps().DismissalDate = dismissaldate
 	return p
 }
 
@@ -399,8 +410,8 @@ func (p *Payload) StaleDate(staledate int64) *Payload {
 // ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
 // {"aps":{"events":"update"}}
-func (p *Payload) Events(event string) *Payload {
-	p.aps().Events = event
+func (p *Payload) Event(event string) *Payload {
+	p.aps().Event = event
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -23,6 +23,8 @@ const (
 	InterruptionLevelCritical EInterruptionLevel = "critical"
 )
 
+type D map[string]interface{}
+
 // Payload represents a notification which holds the content that will be
 // marshalled as JSON.
 type Payload struct {
@@ -30,19 +32,20 @@ type Payload struct {
 }
 
 type aps struct {
-	Alert             interface{}        `json:"alert,omitempty"`
-	Badge             interface{}        `json:"badge,omitempty"`
-	Category          string             `json:"category,omitempty"`
-	ContentAvailable  int                `json:"content-available,omitempty"`
-	InterruptionLevel EInterruptionLevel `json:"interruption-level,omitempty"`
-	MutableContent    int                `json:"mutable-content,omitempty"`
-	RelevanceScore    interface{}        `json:"relevance-score,omitempty"`
-	Sound             interface{}        `json:"sound,omitempty"`
-	ThreadID          string             `json:"thread-id,omitempty"`
-	URLArgs           []string           `json:"url-args,omitempty"`
-	StaleDate         int64              `json:"stale-date,omitempty"`
-	Event             string             `json:"event,omitempty"`
-	Timestamp         int64              `json:"timestamp,omitempty"`
+	Alert             interface{}            `json:"alert,omitempty"`
+	Badge             interface{}            `json:"badge,omitempty"`
+	Category          string                 `json:"category,omitempty"`
+	ContentAvailable  int                    `json:"content-available,omitempty"`
+	InterruptionLevel EInterruptionLevel     `json:"interruption-level,omitempty"`
+	MutableContent    int                    `json:"mutable-content,omitempty"`
+	RelevanceScore    interface{}            `json:"relevance-score,omitempty"`
+	Sound             interface{}            `json:"sound,omitempty"`
+	ThreadID          string                 `json:"thread-id,omitempty"`
+	URLArgs           []string               `json:"url-args,omitempty"`
+	StaleDate         int64                  `json:"stale-date,omitempty"`
+	Event             string                 `json:"event,omitempty"`
+	Timestamp         int64                  `json:"timestamp,omitempty"`
+	ContentState      map[string]interface{} `json:"content-state,omitempty"`
 }
 
 type alert struct {
@@ -396,6 +399,11 @@ func (p *Payload) Event(event string) *Payload {
 // {"aps":{"timestamp":1168364460}}
 func (p *Payload) Timestamp(value int64) *Payload {
 	p.aps().Timestamp = value
+	return p
+}
+
+func (p *Payload) ContentState(content map[string]interface{}) *Payload {
+	p.aps().ContentState = content
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -43,7 +43,7 @@ type aps struct {
 	ThreadID          string                 `json:"thread-id,omitempty"`
 	URLArgs           []string               `json:"url-args,omitempty"`
 	StaleDate         int64                  `json:"stale-date,omitempty"`
-	Event             string                 `json:"event,omitempty"`
+	Events            string                 `json:"event,omitempty"`
 	Timestamp         int64                  `json:"timestamp,omitempty"`
 	ContentState      map[string]interface{} `json:"content-state,omitempty"`
 }
@@ -394,13 +394,13 @@ func (p *Payload) StaleDate(staledate int64) *Payload {
 	return p
 }
 
-// Event defines the value event for the aps payload
+// Events defines the value event for the aps payload
 // Describes whether you update or end an ongoing Live Activity
 // ref: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
 //
-// {"aps":{"event":"update"}}
-func (p *Payload) Event(event string) *Payload {
-	p.aps().Event = event
+// {"aps":{"events":"update"}}
+func (p *Payload) Events(event string) *Payload {
+	p.aps().Events = event
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -247,3 +247,9 @@ func TestTimestamp(t *testing.T) {
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"timestamp":1168364460}}`, string(b))
 }
+
+func TestContentState(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Timestamp(1168364460).StaleDate(12324243).RelevanceScore(0.1).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(b))
+}

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -237,7 +237,7 @@ func TestCombined(t *testing.T) {
 }
 
 func TestEvent(t *testing.T) {
-	payload := NewPayload().Event("update")
+	payload := NewPayload().Events("update")
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"event":"update"}}`, string(data))
 }
@@ -261,13 +261,13 @@ func TestContentState(t *testing.T) {
 }
 
 func TestLiveActivityAttributes(t *testing.T) {
-	payload := NewPayload().Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	payload := NewPayload().Events("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
 }
 
 func TestLiveActivityAttributesMixedWithAlert(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Events("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
 }

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -237,7 +237,7 @@ func TestCombined(t *testing.T) {
 }
 
 func TestEvent(t *testing.T) {
-	payload := NewPayload().Events("update")
+	payload := NewPayload().Event("update")
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"event":"update"}}`, string(data))
 }
@@ -246,6 +246,12 @@ func TestStaleDate(t *testing.T) {
 	payload := NewPayload().StaleDate(12324243)
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"stale-date":12324243}}`, string(data))
+}
+
+func TestDismissalDate(t *testing.T) {
+	payload := NewPayload().DismissalDate(1689811132)
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"dismissal-date":1689811132}}`, string(data))
 }
 
 func TestTimestamp(t *testing.T) {
@@ -261,13 +267,13 @@ func TestContentState(t *testing.T) {
 }
 
 func TestLiveActivityAttributes(t *testing.T) {
-	payload := NewPayload().Events("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	payload := NewPayload().Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
 }
 
 func TestLiveActivityAttributesMixedWithAlert(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Events("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
 	data, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
 }

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -236,20 +236,38 @@ func TestCombined(t *testing.T) {
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf"},"key":"val"}`, string(b))
 }
 
+func TestEvent(t *testing.T) {
+	payload := NewPayload().Event("update")
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"event":"update"}}`, string(data))
+}
+
 func TestStaleDate(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").StaleDate(12324243).RelevanceScore(0.1)
-	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243}}`, string(b))
+	payload := NewPayload().StaleDate(12324243)
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"stale-date":12324243}}`, string(data))
 }
 
 func TestTimestamp(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Timestamp(1168364460).StaleDate(12324243).RelevanceScore(0.1)
-	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"timestamp":1168364460}}`, string(b))
+	payload := NewPayload().Timestamp(1168364460)
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"timestamp":1168364460}}`, string(data))
 }
 
 func TestContentState(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Timestamp(1168364460).StaleDate(12324243).RelevanceScore(0.1).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
-	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(b))
+	payload := NewPayload().ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
+}
+
+func TestLiveActivityAttributes(t *testing.T) {
+	payload := NewPayload().Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
+}
+
+func TestLiveActivityAttributesMixedWithAlert(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Event("update").Timestamp(1168364460).StaleDate(12324243).ContentState(D{"item_id": 3, "availability": 1, "volume": 4.5, "item_status": "ACCEPTED"})
+	data, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"event":"update","timestamp":1168364460,"content-state":{"availability":1,"item_id":3,"item_status":"ACCEPTED","volume":4.5}}}`, string(data))
 }

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -235,3 +235,15 @@ func TestCombined(t *testing.T) {
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf"},"key":"val"}`, string(b))
 }
+
+func TestStaleDate(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").StaleDate(12324243).RelevanceScore(0.1)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243}}`, string(b))
+}
+
+func TestTimestamp(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Timestamp(1168364460).StaleDate(12324243).RelevanceScore(0.1)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"relevance-score":0.1,"sound":"Default.caf","stale-date":12324243,"timestamp":1168364460}}`, string(b))
+}


### PR DESCRIPTION
___

Documentation reference to  Header `aps-push-type` -> https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns

Documentation reference for  aps payload to support live-activity ->
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943360

## Purpose: 

- add support for live-activity payload
` stale-date`
`content-state`
`timestamp`
`event` **

- add support for live-activity header
   

**NOTE: To verify if correct field is `event` or `events` apple docs could have a typo error 


## Change Files:
`notification.go` ->  support `liveactivity` header 
`payload/builder.go` -> implenting `stale-date`, `content-state`, `timestamp` and `event` to `aps` payload 


TEST results:
<img width="1146" alt="image" src="https://github.com/GonzaloAvilez/apns2/assets/18094168/eebd0ecf-c4bb-4ba0-a298-070169fd756f">


tests passed
<img width="710" alt="image" src="https://github.com/GonzaloAvilez/apns2/assets/18094168/5b21ddaa-5f18-4190-8988-a154fb0cd082">

<img width="686" alt="image" src="https://github.com/GonzaloAvilez/apns2/assets/18094168/b0f4ef03-c5eb-4305-bfca-42054019b7e0">

